### PR TITLE
Use scapy to build an ICMP packet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ bootstrap:
 	uv sync --dev
 
 .PHONY: check
-check: black lint
+check: black lint ty
 
 .PHONY: black
 black:
@@ -20,6 +20,10 @@ lint:
 .PHONY: mypy
 mypy:
 	uv run mypy $(CODEDIRS)
+
+.PHONY: ty
+ty:
+	uv run ty check $(CODEDIRS)
 
 .PHONY: fix
 fix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [project.scripts]
 hashcodes = "ft8ping.hashcodes:main"
 std_call_to_c28 = "ft8ping.std_call_to_c28:main"
+ft8ping = "ft8ping.ft8ping:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,5 @@ dev = [
     "mypy",
     "pytest",
     "ruff",
+    "ty>=0.0.0a8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ dependencies = [
     "structlog",
 ]
 
+[project.scripts]
+hashcodes = "ft8ping.hashcodes:main"
+std_call_to_c28 = "ft8ping.std_call_to_c28:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 description = "ICMP over FT8"
 requires-python = ">=3.12"
 dependencies = [
+    "scapy>=2.6.1",
     "structlog",
 ]
 

--- a/src/ft8ping/ft8ping.py
+++ b/src/ft8ping/ft8ping.py
@@ -1,0 +1,81 @@
+import structlog
+from scapy.all import ICMP, raw
+
+from .hashcodes import hashcodes
+from .std_call_to_c28 import std_call_to_c28
+
+log = structlog.get_logger()
+
+
+def make_icmp_fields(source: str, destination: str):
+
+    encoded_source = std_call_to_c28(source)  # 28 bits
+    log.info(
+        "Encoded callsign as c28",
+        callsign=source,
+        c28=encoded_source,
+        c28_hex=hex(encoded_source),
+    )
+
+    encoded_destination = hashcodes(destination)[0]  # First hash is the 10-bit one
+    log.info(
+        "Hashed callsign as h10",
+        callsign=destination,
+        h10=encoded_destination,
+        h10_hex=hex(encoded_destination),
+    )
+
+    id_val = encoded_source >> 12  # First 16 bits
+
+    # Remaining 12 bits of c28 + first 4 bits of h10
+    seq_val = (encoded_source & 0xFFF) << 4 | encoded_destination >> 6
+
+    # Remaining 6 bits of h10
+    # TODO LIES it's 8 bits
+    payload_val = (encoded_destination & 0x3F).to_bytes(1, "big")
+
+    log.info(
+        "Built ICMP fields",
+        id_val=id_val,
+        seq_val=seq_val,
+        payload_val=payload_val,
+    )
+
+    return (id_val, seq_val, payload_val)
+
+
+def make_ping(source: str, destination: str):
+    id_val, seq_val, payload_val = make_icmp_fields(source, destination)
+
+    req = ICMP(id=id_val, seq=seq_val)
+    req /= payload_val
+
+    log.info("Made packet", packet=req, raw=raw(req))
+
+    return req
+
+
+def parse_ping(packet):
+    id_val = packet.id
+    seq_val = packet.seq
+    payload_val = bytes(packet.payload)
+
+    return parse_fields(id_val, seq_val, payload_val)
+
+
+def parse_fields(id_val, seq_val, payload_val):
+    source_c28 = (id_val << 12) | ((seq_val & 0xFFF0) >> 4)
+    destination_h10 = ((seq_val & 0xF) << 6) | int.from_bytes(
+        payload_val, "big"
+    )  # FIXME
+
+    return (source_c28, destination_h10)
+
+
+def main():
+    p = make_ping("2E0KGG", "G4HSK")
+    print(p)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/ft8ping/ft8ping.py
+++ b/src/ft8ping/ft8ping.py
@@ -1,5 +1,5 @@
 import structlog
-from scapy.all import ICMP, raw
+from scapy.all import ICMP, raw  # ty: ignore[unresolved-import]
 
 from .hashcodes import hashcodes
 from .std_call_to_c28 import std_call_to_c28
@@ -7,7 +7,7 @@ from .std_call_to_c28 import std_call_to_c28
 log = structlog.get_logger()
 
 
-def make_icmp_fields(source: str, destination: str):
+def make_icmp_fields(source: str, destination: str) -> tuple[int, int, bytes]:
 
     encoded_source = std_call_to_c28(source)  # 28 bits
     log.info(
@@ -44,7 +44,7 @@ def make_icmp_fields(source: str, destination: str):
     return (id_val, seq_val, payload_val)
 
 
-def make_ping(source: str, destination: str):
+def make_ping(source: str, destination: str) -> ICMP:
     id_val, seq_val, payload_val = make_icmp_fields(source, destination)
 
     req = ICMP(id=id_val, seq=seq_val)
@@ -55,7 +55,7 @@ def make_ping(source: str, destination: str):
     return req
 
 
-def parse_ping(packet):
+def parse_ping(packet: ICMP) -> tuple[int, int]:
     id_val = packet.id
     seq_val = packet.seq
     payload_val = bytes(packet.payload)
@@ -63,7 +63,7 @@ def parse_ping(packet):
     return parse_fields(id_val, seq_val, payload_val)
 
 
-def parse_fields(id_val, seq_val, payload_val):
+def parse_fields(id_val: int, seq_val: int, payload_val: bytes) -> tuple[int, int]:
     source_c28 = (id_val << 12) | ((seq_val & 0xFFF0) >> 4)
     destination_h10 = ((seq_val & 0xF) << 6) | int.from_bytes(
         payload_val, "big"

--- a/test/test_ft8ping.py
+++ b/test/test_ft8ping.py
@@ -1,0 +1,28 @@
+from ft8ping import ft8ping
+from ft8ping.hashcodes import hashcodes
+from ft8ping.std_call_to_c28 import std_call_to_c28
+
+
+def test_invert():
+    source = "G8GKA"
+    c28 = std_call_to_c28(source)
+
+    destination = "M6KGG"
+    h10 = hashcodes(destination)[0]
+
+    packet = ft8ping.make_ping(source, destination)
+
+    decoded_c28, decoded_h10 = ft8ping.parse_ping(packet)
+
+    assert c28 == decoded_c28
+    assert h10 == decoded_h10
+
+
+def test_main_no_args(capsys, monkeypatch):
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", ["ft8ping.py"])
+        ft8ping.main()
+
+    out = capsys.readouterr().out
+
+    assert "packet" in out

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -116,6 +117,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty", specifier = ">=0.0.0a8" },
 ]
 
 [[package]]
@@ -253,6 +255,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/fe/578db23e17392a8693b45a7b7dc6985370f51dd937157def8ecc7b20930d/structlog-25.1.0.tar.gz", hash = "sha256:2ef2a572e0e27f09664965d31a576afe64e46ac6084ef5cec3c2b8cd6e4e3ad3", size = 1364973, upload-time = "2025-01-16T13:04:09.792Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/14/e9aed6c820fa166e8a19a19e663e98bd5538004d68a70c5752458ca3656e/structlog-25.1.0-py3-none-any.whl", hash = "sha256:843fe4f254540329f380812cbe612e1af5ec5b8172205ae634679cd35a6d6321", size = 68921, upload-time = "2025-01-16T13:04:06.69Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.0a8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/aa/0700b67af527edfe6d35d5bd82e6019c65363390bea9f8e4995c78e480d8/ty-0.0.0a8.tar.gz", hash = "sha256:f00c19020d8c7d5806d54564d4a1fe7e5c6efd5743cefddf619575451491496e", size = 2843192, upload-time = "2025-05-09T18:34:34.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/43/8af99166cfbe993fdcf3bb42d2583876a0ec7bf9c1aac6b9bfb517f8711d/ty-0.0.0a8-py3-none-linux_armv6l.whl", hash = "sha256:b1a86035380fd85ad7428dd8a1001d03b5bc31ef8453ef75c712b12511f4edaa", size = 6182530, upload-time = "2025-05-09T18:33:39.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e5/0e165822733a5dccc74abc840ac546568fcd0253fb9ef0e52e9d243a9703/ty-0.0.0a8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0b7522562908da2a2189441cc787646479aceb95ab6296bc805e2d89ef867b43", size = 6279778, upload-time = "2025-05-09T18:33:42.816Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b0/740cae6ad23db80f70abccd0fe675eb4c836affd5e772cc9a5336f473ab4/ty-0.0.0a8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b2725a5bc8924578a9687bebbb840187f9ae2a2ae5583129aac4e037934b2eea", size = 5942076, upload-time = "2025-05-09T18:33:47.581Z" },
+    { url = "https://files.pythonhosted.org/packages/54/29/34ae8567ba4e2acea27fddea3261b2d7d74140a47c950a1ed47844658d9c/ty-0.0.0a8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98174efc5cd8991b64b141eb0531f055460f7f2f37b24c11d84c37b79c5942a6", size = 6068046, upload-time = "2025-05-09T18:33:50.33Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b0/9649d3bc9a6be61eddb28d2d4cee7bc395a29b6c5adc7b78a34ea6b99a84/ty-0.0.0a8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:55d69343312b615631152a1a5748bb6b42799f09f1732720e080220ea54ef1f5", size = 6042137, upload-time = "2025-05-09T18:33:53.653Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/a12be911a3f027dd67cc6a4d23b4db95be1d14a17cda53a44e15d992bf18/ty-0.0.0a8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f9bc829ef45ea3ce0427f58fcab7a7c9d00b3f9696066a0f3002db43d7a4e52", size = 6744589, upload-time = "2025-05-09T18:33:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ea/388681a052fe27a4f923037e27a2c0c84431fdb90f7fb412389dbf7bf7f6/ty-0.0.0a8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0635e72feb984944d7477035b78dcf38618a9f9f01bd5c45204c9d92eef6e1b8", size = 7169411, upload-time = "2025-05-09T18:34:00.828Z" },
+    { url = "https://files.pythonhosted.org/packages/36/cf/6ab82918008db4be191df6efd585b329a5a7b814e5a4e29adf4f4cfa07e6/ty-0.0.0a8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1eba8ea7e2d820d304883b6608e464700c5ae3b4fee391800f286e062f8212d4", size = 6811515, upload-time = "2025-05-09T18:34:05.155Z" },
+    { url = "https://files.pythonhosted.org/packages/44/79/c2f780e26d00906ec0f9561ec421d99cc60ac54be9eef6c21ec2c90c68cf/ty-0.0.0a8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea51192cef819b7f9fc84586bccdccbcde5221a2041e736db7cf3bf3611e3336", size = 7615265, upload-time = "2025-05-09T18:34:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f8/17e52152c384a1804466b989b97dc15e392885b97b6051bec86bcb9d8311/ty-0.0.0a8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3aeedb99ede34bc16081d5540b5e08e96a52fb6bfc2b1e3ce57908ea1013e5ea", size = 6551290, upload-time = "2025-05-09T18:34:10.981Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ce/143a14814e12d94377059707b1a7026fe96ee1bdd3c7397f49e29ac8b2ab/ty-0.0.0a8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:33851d860d9044249f81aec19ac02e7b0bff13f94d713482328927142f20fbaf", size = 5987829, upload-time = "2025-05-09T18:34:13.542Z" },
+    { url = "https://files.pythonhosted.org/packages/55/36/e4fab57a67fba2cc666be03be692b8f90ab2adc7d398eea951e60d9c1d18/ty-0.0.0a8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aa7140d67b6a4b2a1cbe2c7536d3af1be16d095cc36da87cdd1986084a80eab9", size = 6069987, upload-time = "2025-05-09T18:34:16.517Z" },
+    { url = "https://files.pythonhosted.org/packages/72/61/1c6acfefb880781c78312fdd77911340aad170e55446482afcf1012ad258/ty-0.0.0a8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:35c5422739cb04198163539b0d7e0cd867b5c19a083499d92b79b0565da1b014", size = 6458886, upload-time = "2025-05-09T18:34:19.446Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c7/76ee868b54e8d34db6ad28af155a9bb3af6a37edf67132b8550d2bf92892/ty-0.0.0a8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ec7ce7d8e5b274b7496ffe04ac63db7455d6e7afd1a037d584ea98b4fd61c095", size = 6609876, upload-time = "2025-05-09T18:34:22.748Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/70/deb7acea25321bef0c789626515835bda2110e68cff3b999771850ac6596/ty-0.0.0a8-py3-none-win32.whl", hash = "sha256:1d537231769bb0ae6c678a696ed0cf93a56cf998ce27a3ffc1cf36b5f02b629b", size = 5882195, upload-time = "2025-05-09T18:34:25.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/be/6ce577f3063e9bbba8df14b23fb0348d6a56df3af2c2307f7adda9f46405/ty-0.0.0a8-py3-none-win_amd64.whl", hash = "sha256:5f2f4d836c569ed7d50fef5eaf342fd869868341ae6181a31ac7a474e00cdc75", size = 6353690, upload-time = "2025-05-09T18:34:27.847Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4d/6da3b067af63fabf612025c32df639b8e146298600b58cf7c015faab503f/ty-0.0.0a8-py3-none-win_arm64.whl", hash = "sha256:9420018ea3dae0138d6d5c6a508bc7051a2ec7d3ced69bc2ec6517096bb88e29", size = 6016368, upload-time = "2025-05-09T18:34:31.6Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,7 @@ name = "ft8ping"
 version = "0"
 source = { editable = "." }
 dependencies = [
+    { name = "scapy" },
     { name = "structlog" },
 ]
 
@@ -103,7 +104,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "structlog" }]
+requires-dist = [
+    { name = "scapy", specifier = ">=2.6.1" },
+    { name = "structlog" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -231,6 +235,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/15/f6751c07c21ca10e3f4a51ea495ca975ad936d780c347d9808bcedbd7182/ruff-0.9.4-py3-none-win32.whl", hash = "sha256:db1192ddda2200671f9ef61d9597fcef89d934f5d1705e571a93a67fb13a4402", size = 9852302, upload-time = "2025-01-30T18:09:40.013Z" },
     { url = "https://files.pythonhosted.org/packages/12/41/2d2d2c6a72e62566f730e49254f602dfed23019c33b5b21ea8f8917315a1/ruff-0.9.4-py3-none-win_amd64.whl", hash = "sha256:05bebf4cdbe3ef75430d26c375773978950bbf4ee3c95ccb5448940dc092408e", size = 10850051, upload-time = "2025-01-30T18:09:43.42Z" },
     { url = "https://files.pythonhosted.org/packages/c6/e6/3d6ec3bc3d254e7f005c543a661a41c3e788976d0e52a1ada195bd664344/ruff-0.9.4-py3-none-win_arm64.whl", hash = "sha256:585792f1e81509e38ac5123492f8875fbc36f3ede8185af0a26df348e5154f41", size = 10078251, upload-time = "2025-01-30T18:09:48.01Z" },
+]
+
+[[package]]
+name = "scapy"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/2f/035d3888f26d999e9680af8c7ddb7ce4ea0fd8d0e01c000de634c22dcf13/scapy-2.6.1.tar.gz", hash = "sha256:7600d7e2383c853e5c3a6e05d37e17643beebf2b3e10d7914dffcc3bc3c6e6c5", size = 2247754, upload-time = "2024-11-05T08:43:23.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/34/8695b43af99d0c796e4b7933a0d7df8925f43a8abdd0ff0f6297beb4de3a/scapy-2.6.1-py3-none-any.whl", hash = "sha256:88a998572049b511a1f3e44f4aa7c62dd39c6ea2aa1bb58434f503956641789d", size = 2420670, upload-time = "2024-11-05T08:43:21.285Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **Add Scapy**
- **Add hashcodes and std_call_to_c28 as project.scripts**
- **Add "ft8ping" to generate an ICMP packet from src/dest callsigns**
- **Add ty for *fast* type-checking, as well as some more hints**
