### PR TITLE
Selectively import from scapy for speed

### DIFF
--- a/src/ft8ping/ft8ping.py
+++ b/src/ft8ping/ft8ping.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import click
 import structlog
-from scapy.all import ICMP, raw  # ty: ignore[unresolved-import]
+from scapy.compat import raw
+from scapy.layers.inet import ICMP
 
 from .hashcodes import hashcodes
 from .std_call_to_c28 import std_call_to_c28

--- a/test/test_ft8ping.py
+++ b/test/test_ft8ping.py
@@ -2,7 +2,7 @@ import subprocess
 import tempfile
 
 from click.testing import CliRunner
-from scapy.all import ICMP  # ty: ignore[unresolved-import]
+from scapy.layers.inet import ICMP
 
 from ft8ping import ft8ping
 from ft8ping.hashcodes import hashcodes


### PR DESCRIPTION
Still slower than ideal, but *better*

$ git switch feature/faster
$ time uv run ft8ping --help > /dev/null

real    0m1.542s
user    0m1.412s
sys     0m0.135s

$ git switch main
$ time uv run ft8ping --help > /dev/null

real    0m2.334s
user    0m2.177s
sys     0m0.158s
